### PR TITLE
Increase default timeout in wait_for function

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -26,7 +26,7 @@ help    : Show this message
 wait_for() {
     # Wait for hosts specified in WAIT_FOR
     echo "Waiting for neighbors..." >&2
-    TIMEOUT=${TIMEOUT:-45}
+    TIMEOUT=${TIMEOUT:-90}
     result=0    # exit right away if list is empty
     for i in $(seq "$TIMEOUT"); do
         for TARGET in $WAIT_FOR; do


### PR DESCRIPTION
Increased the default timeout for waiting for neighbors from 45 to 90 seconds.

timeout occures before aim-web can finish its migration codebuild [link](https://us-east-1.console.aws.amazon.com/codesuite/codebuild/659004559364/projects/aim-flatstrip-codebuild-cicd/build/aim-flatstrip-codebuild-cicd%3Abc69bd67-645c-4dc5-a91c-e707410dc6a8?region=us-east-1) and logs:

```

Container flatstrip_20newman-check_connection-run-ed4ea5f97db6 Creating
--
Container flatstrip_20newman-check_connection-run-ed4ea5f97db6 Created
Waiting for neighbors...
bash: connect: Connection refused
bash: line 1: /dev/tcp/flatstrip/8000: Connection refused
bash: connect: Connection refused
bash: line 1: /dev/tcp/flatstrip/8000: Connection refused
bash: connect: Connection refused
bash: line 1: /dev/tcp/flatstrip/8000: Connection refused
bash: connect: Connection refused
bash: line 1: /dev/tcp/flatstrip/8000: Connection refused
bash: connect: Connection refused
bash: line 1: /dev/tcp/flatstrip/8000: Connection refused
bash: connect: Connection refused
bash: line 1: /dev/tcp/flatstrip/8000: Connection refused
bash: connect: Connection refused
bash: line 1: /dev/tcp/flatstrip/8000: Connection refused
bash: connect: Connection refused
bash: line 1: /dev/tcp/flatstrip/8000: Connection refused
bash: connect: Connection refused
bash: line 1: /dev/tcp/flatstrip/8000: Connection refused
bash: connect: Connection refused
bash: line 1: /dev/tcp/aimweb/8000: Connection refused
bash: connect: Connection refused
bash: line 1: /dev/tcp/aimweb/8000: Connection refused
bash: connect: Connection refused
bash: line 1: /dev/tcp/aimweb/8000: Connection refused
bash: connect: Connection refused
bash: line 1: /dev/tcp/aimweb/8000: Connection refused
bash: connect: Connection refused
bash: line 1: /dev/tcp/aimweb/8000: Connection refused
bash: connect: Connection refused
bash: line 1: /dev/tcp/aimweb/8000: Connection refused
bash: connect: Connection refused
bash: line 1: /dev/tcp/aimweb/8000: Connection refused
bash: connect: Connection refused
bash: line 1: /dev/tcp/aimweb/8000: Connection refused
bash: connect: Connection refused
bash: line 1: /dev/tcp/aimweb/8000: Connection refused
bash: connect: Connection refused
bash: line 1: /dev/tcp/aimweb/8000: Connection refused
bash: connect: Connection refused
bash: line 1: /dev/tcp/aimweb/8000: Connection refused
bash: connect: Connection refused
bash: line 1: /dev/tcp/aimweb/8000: Connection refused
bash: connect: Connection refused
bash: line 1: /dev/tcp/aimweb/8000: Connection refused
bash: connect: Connection refused
bash: line 1: /dev/tcp/aimweb/8000: Connection refused
bash: connect: Connection refused
bash: line 1: /dev/tcp/aimweb/8000: Connection refused
bash: connect: Connection refused
bash: line 1: /dev/tcp/aimweb/8000: Connection refused
bash: connect: Connection refused
bash: line 1: /dev/tcp/aimweb/8000: Connection refused
bash: connect: Connection refused
bash: line 1: /dev/tcp/aimweb/8000: Connection refused
bash: connect: Connection refused
bash: line 1: /dev/tcp/aimweb/8000: Connection refused
bash: connect: Connection refused
bash: line 1: /dev/tcp/aimweb/8000: Connection refused
bash: connect: Connection refused
bash: line 1: /dev/tcp/aimweb/8000: Connection refused
bash: connect: Connection refused
bash: line 1: /dev/tcp/aimweb/8000: Connection refused
bash: connect: Connection refused
bash: line 1: /dev/tcp/aimweb/8000: Connection refused
bash: connect: Connection refused
bash: line 1: /dev/tcp/aimweb/8000: Connection refused
bash: connect: Connection refused
bash: line 1: /dev/tcp/aimweb/8000: Connection refused
bash: connect: Connection refused
bash: line 1: /dev/tcp/aimweb/8000: Connection refused
bash: connect: Connection refused
bash: line 1: /dev/tcp/aimweb/8000: Connection refused
bash: connect: Connection refused
bash: line 1: /dev/tcp/aimweb/8000: Connection refused
bash: connect: Connection refused
bash: line 1: /dev/tcp/aimweb/8000: Connection refused
bash: connect: Connection refused
bash: line 1: /dev/tcp/aimweb/8000: Connection refused
bash: connect: Connection refused
bash: line 1: /dev/tcp/aimweb/8000: Connection refused
bash: connect: Connection refused
bash: line 1: /dev/tcp/aimweb/8000: Connection refused
bash: connect: Connection refused
bash: line 1: /dev/tcp/aimweb/8000: Connection refused
bash: connect: Connection refused
bash: line 1: /dev/tcp/aimweb/8000: Connection refused
bash: connect: Connection refused
bash: line 1: /dev/tcp/aimweb/8000: Connection refused
bash: connect: Connection refused
bash: line 1: /dev/tcp/aimweb/8000: Connection refused
Operation timed out


Init failure. Collecting debug info for aimweb...
time="2026-05-05T14:31:02Z" level=warning msg="/codebuild/output/src3393803033/src/github.com/JCAII/aim-flatstrip/ci/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion"
time="2026-05-05T14:31:02Z" level=warning msg="/codebuild/output/src3393803033/src/github.com/JCAII/aim-flatstrip/ci/docker-compose.20newman.test.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion"
NAME                                                        IMAGE                                                                                               COMMAND                  SERVICE        CREATED          STATUS          PORTS
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web      659004559364.dkr.ecr.us-east-1.amazonaws.com/aim-web:3694_ReRoute_Flatstrip_to_Web_build_2675       "/app/entrypoint.sh …"   aimweb         50 seconds ago   Up 50 seconds   8000/tcp
flatstrip-20newman-db-370_ReRoute_FlatStrip_to_Web          public.ecr.aws/docker/library/postgres:14.20                                                        "docker-entrypoint.s…"   database       50 seconds ago   Up 50 seconds   5432/tcp
flatstrip-20newman-dbweb-370_ReRoute_FlatStrip_to_Web       public.ecr.aws/docker/library/postgres:14.20                                                        "docker-entrypoint.s…"   database_web   50 seconds ago   Up 50 seconds   5432/tcp
flatstrip-20newman-flatstrip-370_ReRoute_FlatStrip_to_Web   659004559364.dkr.ecr.us-east-1.amazonaws.com/aim-flatstrip:370_ReRoute_FlatStrip_to_Web_build_349   "/app/entrypoint.sh …"   flatstrip      50 seconds ago   Up 50 seconds   8000/tcp
flatstrip-20newman-redis-370_ReRoute_FlatStrip_to_Web       public.ecr.aws/docker/library/redis:5                                                               "docker-entrypoint.s…"   redis          50 seconds ago   Up 50 seconds   6379/tcp
--- AIMWEB LOGS ---
time="2026-05-05T14:31:02Z" level=warning msg="/codebuild/output/src3393803033/src/github.com/JCAII/aim-flatstrip/ci/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion"
time="2026-05-05T14:31:03Z" level=warning msg="/codebuild/output/src3393803033/src/github.com/JCAII/aim-flatstrip/ci/docker-compose.20newman.test.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion"
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Airline VIV doesn't exist!
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  | 
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Populating for VLG
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Airline VLG doesn't exist!
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  | 
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Populating for WZM
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Airline WZM doesn't exist!
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  | 
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Populating for WJA
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Airline WJA doesn't exist!
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  | 
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Populating for WEN
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Airline WEN doesn't exist!
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  | 
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Populating for TCX
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Airline TCX doesn't exist!
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  | 
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Populating for VOI
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Airline VOI doesn't exist!
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  | 
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Populating for WWD
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Airline WWD doesn't exist!
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |  OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying job.0078_auto_20211215_1848... OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying job.0079_auto_20211229_1935... OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying job.0080_flightstrip_pilot_communication_tmp... OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying job.0081_auto_20220323_2134... OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying job.0082_remove_flightstrip_pilot_communication_tmp... OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying override.0001_squashed_0018_auto_20180420_1446... OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying override.0002_auto_20180923_2308... OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying override.0003_auto_20181025_2116... OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying override.0003_auto_20181024_1455... OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying override.0004_merge_20181106_1842... OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying override.0004_auto_20181116_1645... OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying override.0005_merge_20181127_1617... OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying override.0006_flightstripoverride_source... OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying override.0007_auto_20190105_2114... OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying override.0008_auto_20190104_1411... OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying override.0009_auto_20190105_2240... OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying override.0010_auto_20190105_2316... OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying override.0011_auto_20190107_1602... OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying override.0012_auto_20190108_1817... OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying override.0006_flightstripoverride_labels... OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying override.0013_merge_20190129_2200... OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying override.0014_flightstripoverride_pre_spray... OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying override.0015_auto_20190322_1523... OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying override.0016_auto_20190322_2021... OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying override.0017_remove_crewoverride_communicated_with_pilot... OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying override.0018_auto_20191016_1734... OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying override.0019_flightstripoverride_nozzle_close_time... OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying override.0019_auto_20200106_2034... OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying override.0020_merge_20200114_1946... OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying override.0021_flightstripoverride_local_spot_deicing... OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying override.0022_auto_20200312_0348... OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying override.0023_auto_20200529_1410... OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying override.0024_auto_20200703_1223... OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying override.0025_auto_20200911_2042... OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying manual_entry.0001_squashed_0006_auto_20180420_1446... OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying manual_entry.0002_auto_20180923_2308... OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying manual_entry.0003_auto_20181024_1455... OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying manual_entry.0004_auto_20181116_1645... OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying manual_entry.0005_mfeflightstrip_labels... OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying manual_entry.0005_auto_20190108_1650... OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying manual_entry.0006_merge_20190129_2200... OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying manual_entry.0007_mfeflightstrip_pre_spray... OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying manual_entry.0008_auto_20190402_2350... OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying manual_entry.0009_auto_20190501_2034... OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying manual_entry.0010_fix_volumes... OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying manual_entry.0011_auto_20190719_1331... OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying manual_entry.0012_auto_20191001_1811... OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying manual_entry.0013_populate_nozzle_close... OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying manual_entry.0012_auto_20191016_1734... OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying manual_entry.0013_auto_20191016_1746... OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying manual_entry.0014_merge_20191127_1951... OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying manual_entry.0015_auto_20200103_1726... OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying manual_entry.0016_auto_20200106_2034... OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying manual_entry.0015_auto_20200109_1047... OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying manual_entry.0017_merge_20200114_1946... OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying manual_entry.0018_mfeflightstrip_local_spot_deicing... OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying manual_entry.0019_auto_20200312_0348... OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying manual_entry.0020_auto_20200609_1111... OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying manual_entry.0021_auto_20200703_1223... OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying override.0026_fill_fluid_brands... OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying override.0027_update_fluid_brand...
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  | ACHTUNG: cannot find fluid brands for data migration!!! Skipping...
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  | It's okay in case you have non-production data
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |  OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying override.0028_more_fluid_brand_updates...
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  | ACHTUNG: cannot find fluid brands for data migration!!! Skipping...
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  | It's okay in case you have non-production data
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |  OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying override.0029_update_fluid_brands_for_mfe...
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  | ACHTUNG: cannot find fluid brands for data migration!!! Skipping...
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  | It's okay in case you have non-production data
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |  OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying override.0030_flightstripoverride_deice_treatment_start_datetime... OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying override.0031_auto_20211103_1340... OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying override.0031_alter_flightstripoverride_contamination... OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying override.0032_merge_20220107_1851... OK
flatstrip-20newman-aimweb-370_ReRoute_FlatStrip_to_Web  |   Applying override.0033_flightstrip_override_start_time... OK
--- FLATSTRIP LOGS ---
time="2026-05-05T14:31:03Z" level=warning msg="/codebuild/output/src3393803033/src/github.com/JCAII/aim-flatstrip/ci/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion"
time="2026-05-05T14:31:03Z" level=warning msg="/codebuild/output/src3393803033/src/github.com/JCAII/aim-flatstrip/ci/docker-compose.20newman.test.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion"
flatstrip-20newman-flatstrip-370_ReRoute_FlatStrip_to_Web  | Waiting for neighbors...
flatstrip-20newman-flatstrip-370_ReRoute_FlatStrip_to_Web  | bash: connect: Connection refused
flatstrip-20newman-flatstrip-370_ReRoute_FlatStrip_to_Web  | bash: line 1: /dev/tcp/database/5432: Connection refused
flatstrip-20newman-flatstrip-370_ReRoute_FlatStrip_to_Web  | bash: connect: Connection refused
flatstrip-20newman-flatstrip-370_ReRoute_FlatStrip_to_Web  | bash: line 1: /dev/tcp/database/5432: Connection refused
flatstrip-20newman-flatstrip-370_ReRoute_FlatStrip_to_Web  | Done waiting
flatstrip-20newman-flatstrip-370_ReRoute_FlatStrip_to_Web  | Initializing database...
flatstrip-20newman-flatstrip-370_ReRoute_FlatStrip_to_Web  | Operations to perform:
flatstrip-20newman-flatstrip-370_ReRoute_FlatStrip_to_Web  |   Synchronize unmigrated apps: account, admin, api, auth, authtoken, contenttypes, django_extensions, flatstrip, flightstrip, messages, oauth2_provider, rest_framework, sessions, staticfiles, storages
flatstrip-20newman-flatstrip-370_ReRoute_FlatStrip_to_Web  |   Apply all migrations: (none)
flatstrip-20newman-flatstrip-370_ReRoute_FlatStrip_to_Web  | Synchronizing apps without migrations:
flatstrip-20newman-flatstrip-370_ReRoute_FlatStrip_to_Web  |   Creating tables...
flatstrip-20newman-flatstrip-370_ReRoute_FlatStrip_to_Web  |     Creating table django_admin_log
flatstrip-20newman-flatstrip-370_ReRoute_FlatStrip_to_Web  |     Creating table auth_permission
flatstrip-20newman-flatstrip-370_ReRoute_FlatStrip_to_Web  |     Creating table auth_group
flatstrip-20newman-flatstrip-370_ReRoute_FlatStrip_to_Web  |     Creating table django_content_type
flatstrip-20newman-flatstrip-370_ReRoute_FlatStrip_to_Web  |     Creating table django_session
flatstrip-20newman-flatstrip-370_ReRoute_FlatStrip_to_Web  |     Creating table authtoken_token
flatstrip-20newman-flatstrip-370_ReRoute_FlatStrip_to_Web  |     Creating table oauth2_provider_grant
flatstrip-20newman-flatstrip-370_ReRoute_FlatStrip_to_Web  |     Creating table oauth2_provider_accesstoken
flatstrip-20newman-flatstrip-370_ReRoute_FlatStrip_to_Web  |     Creating table oauth2_provider_refreshtoken
flatstrip-20newman-flatstrip-370_ReRoute_FlatStrip_to_Web  |     Creating table oauth2_provider_idtoken
flatstrip-20newman-flatstrip-370_ReRoute_FlatStrip_to_Web  |     Creating table api_application
flatstrip-20newman-flatstrip-370_ReRoute_FlatStrip_to_Web  |     Creating table api_refreshsession
flatstrip-20newman-flatstrip-370_ReRoute_FlatStrip_to_Web  |     Creating table api_service
flatstrip-20newman-flatstrip-370_ReRoute_FlatStrip_to_Web  |     Creating table api_servicetoken
flatstrip-20newman-flatstrip-370_ReRoute_FlatStrip_to_Web  |     Creating table api_identtoken
flatstrip-20newman-flatstrip-370_ReRoute_FlatStrip_to_Web  |     Creating table account_user
flatstrip-20newman-flatstrip-370_ReRoute_FlatStrip_to_Web  |     Creating table flightstrip_flightstrip
flatstrip-20newman-flatstrip-370_ReRoute_FlatStrip_to_Web  |     Running deferred SQL...
flatstrip-20newman-flatstrip-370_ReRoute_FlatStrip_to_Web  | Running migrations:
flatstrip-20newman-flatstrip-370_ReRoute_FlatStrip_to_Web  |   No migrations to apply.
flatstrip-20newman-flatstrip-370_ReRoute_FlatStrip_to_Web  | Initializing database complete
flatstrip-20newman-flatstrip-370_ReRoute_FlatStrip_to_Web  | Running setup commands...
flatstrip-20newman-flatstrip-370_ReRoute_FlatStrip_to_Web  | Done setting up
flatstrip-20newman-flatstrip-370_ReRoute_FlatStrip_to_Web  | [2026-05-05 14:30:25 +0000] [1] [INFO] Starting gunicorn 23.0.0
flatstrip-20newman-flatstrip-370_ReRoute_FlatStrip_to_Web  | [2026-05-05 14:30:25 +0000] [1] [INFO] Listening at: http://0.0.0.0:8000 (1)
flatstrip-20newman-flatstrip-370_ReRoute_FlatStrip_to_Web  | [2026-05-05 14:30:25 +0000] [1] [INFO] Using worker: sync
flatstrip-20newman-flatstrip-370_ReRoute_FlatStrip_to_Web  | [2026-05-05 14:30:25 +0000] [62] [INFO] Booting worker with pid: 62

[Container] 2026/05/05 14:31:03.065233 Command did not exit successfully bash ./ci/20newman.test.sh 20newman exit status 1
[Container] 2026/05/05 14:31:03.073684 Phase complete: BUILD State: FAILED_WITH_ABORT
[Container] 2026/05/05 14:31:03.073707 Phase context status code: COMMAND_EXECUTION_ERROR Message: Error while executing command: bash ./ci/20newman.test.sh 20newman. Reason: exit status 1
```